### PR TITLE
Update SentryReactNative.podspec to remove RSSwizzle

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -20,7 +20,6 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'Sentry', '~> 3.0.1'
   s.dependency 'KSCrash', '~> 1.15.8'
-  s.dependency 'RSSwizzle', '~> 0.1.0'
 
   s.source_files = 'ios/RNSentry*.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'


### PR DESCRIPTION
Full context is in https://github.com/getsentry/sentry-cocoa/issues/169

This should fix a build using CocoaPods for Sentry + SentryReactNative

---

Sigh